### PR TITLE
Rename playback_state into playback

### DIFF
--- a/lib/membrane_portaudio_plugin/sink.ex
+++ b/lib/membrane_portaudio_plugin/sink.ex
@@ -92,7 +92,7 @@ defmodule Membrane.PortAudio.Sink do
   end
 
   @impl true
-  def handle_info({:portaudio_demand, size}, %{playback_state: :playing}, state) do
+  def handle_info({:portaudio_demand, size}, %{playback: :playing}, state) do
     {[demand: {:input, &(&1 + size)}], state}
   end
 

--- a/lib/membrane_portaudio_plugin/source.ex
+++ b/lib/membrane_portaudio_plugin/source.ex
@@ -74,7 +74,7 @@ defmodule Membrane.PortAudio.Source do
   end
 
   @impl true
-  def handle_info({:portaudio_payload, payload}, %{playback_state: :playing}, state) do
+  def handle_info({:portaudio_payload, payload}, %{playback: :playing}, state) do
     {[buffer: {:output, %Buffer{payload: payload}}], state}
   end
 


### PR DESCRIPTION
This PR renames the `playback_state` field in callbacks' contextes into `playback`.
It fixes problems with the callbacks not being properly invoked in both Source and Sink.
