### PR TITLE
Implement different sample rates and channels configurations

### DIFF
--- a/c_src/membrane_portaudio_plugin/pa_helper.c
+++ b/c_src/membrane_portaudio_plugin/pa_helper.c
@@ -40,18 +40,25 @@ char *init_pa(UnifexEnv *env, char *log_tag, StreamDirection direction,
     ret_error = "invalid_latency";
     goto error;
   }
-
-  if(*channels > device_info->maxInputChannels) {
-    switch(direction) {
-      case STREAM_DIRECTION_IN:
-        *channels = device_info->maxInputChannels;
-        break;
-
-      case STREAM_DIRECTION_OUT:
-        return "Incoming stream has more channels than the device can handle";
-    }
-  }
   
+  switch(direction) {
+    case STREAM_DIRECTION_IN:
+      if(*channels == 0) {
+        *channels = device_info->maxInputChannels;
+      } else if (*channels > device_info->maxInputChannels) {
+        return "Device doesn't support that many input channels";
+      }
+      break;
+
+    case STREAM_DIRECTION_OUT:
+      if (*channels > device_info->maxOutputChannels) {
+        return "Device doesn't support that many output channels";
+      } else if (*channels == 0) {
+        return "Channel count must be configured for output mode";
+      }
+      break;
+  }
+
   if(*sample_rate <= 0.0) {
     switch(direction) {
       case STREAM_DIRECTION_IN:

--- a/c_src/membrane_portaudio_plugin/pa_helper.h
+++ b/c_src/membrane_portaudio_plugin/pa_helper.h
@@ -10,8 +10,13 @@ typedef enum { STREAM_DIRECTION_IN, STREAM_DIRECTION_OUT } StreamDirection;
 
 char *init_pa(UnifexEnv *env, char *log_tag, StreamDirection direction,
               PaStream **stream, void *state, PaSampleFormat sample_format,
-              int sample_rate, int channels, char *latency_str, int *latency_ms,
+              double *sample_rate, int *channels, char *latency_str, int *latency_ms,
               int pa_buffer_size, PaDeviceIndex endpoint_id,
               PaStreamCallback *callback);
 
 char *destroy_pa(UnifexEnv *env, char *log_tag, PaStream *stream);
+
+#define UNSUPPORTED_SAMPLE_FORMAT 0
+PaSampleFormat string_to_PaSampleFormat(char* format);
+
+int sample_size(PaSampleFormat);

--- a/c_src/membrane_portaudio_plugin/sink.h
+++ b/c_src/membrane_portaudio_plugin/sink.h
@@ -16,6 +16,8 @@ typedef struct _SinkState {
   UnifexPid membrane_clock;
   int demand;
   int ticks;
+  int sample_rate;
+  int frame_size;
 } SinkState;
 
 #include "_generated/sink.h"

--- a/c_src/membrane_portaudio_plugin/sink.spec.exs
+++ b/c_src/membrane_portaudio_plugin/sink.spec.exs
@@ -8,6 +8,9 @@ spec create(
        demand_handler :: pid,
        clock :: pid,
        endpoint_id :: int,
+       sample_rate :: int,
+       channels :: int,
+       sample_format :: atom,
        ringbuffer_size :: int,
        pa_buffer_size :: int,
        latency :: atom

--- a/c_src/membrane_portaudio_plugin/source.c
+++ b/c_src/membrane_portaudio_plugin/source.c
@@ -44,7 +44,7 @@ static int callback(const void *input_buffer, void *_output_buffer,
 }
 
 UNIFEX_TERM create(UnifexEnv *env, UnifexPid destination, int endpoint_id,
-                   int pa_buffer_size, char *latency, int max_channels) {
+                   int pa_buffer_size, char *latency, int channels, int sample_rate_int) {
   MEMBRANE_DEBUG(env, "Initializing");
 
   SourceState *state = unifex_alloc_state(env);
@@ -52,20 +52,20 @@ UNIFEX_TERM create(UnifexEnv *env, UnifexPid destination, int endpoint_id,
   state->destination = destination;
   state->stream = NULL;
   
-  double sample_rate = -1.0;
+  double sample_rate = (double) sample_rate_int;
 
   int _latency_ms;
   char *error = init_pa(
       env, MEMBRANE_LOG_TAG, STREAM_DIRECTION_IN, &(state->stream), state,
       paInt16, // sample format
       &sample_rate, // device's default sample rate will be selected
-      &max_channels,
+      &channels,
       latency, &_latency_ms, pa_buffer_size, endpoint_id, callback);
   
-  state->channels = max_channels;
+  state->channels = channels;
 
   UNIFEX_TERM res =
-      error ? create_result_error(env, error) : create_result_ok(env, state, max_channels, floor(sample_rate));
+      error ? create_result_error(env, error) : create_result_ok(env, state, channels, floor(sample_rate));
   unifex_release_state(env, state);
   return res;
 }

--- a/c_src/membrane_portaudio_plugin/source.c
+++ b/c_src/membrane_portaudio_plugin/source.c
@@ -2,7 +2,7 @@
 #define MEMBRANE_LOG_TAG "Membrane.PortAudio.Sink"
 #include <membrane/log.h>
 
-#define FRAME_SIZE 4 // TODO hardcoded format, stereo frame, 16bit
+#define SAMPLE_SIZE 2 // TODO hardcoded format, 16bit
 
 void handle_destroy_state(UnifexEnv *env, SourceState *state) {
   if (state->is_content_destroyed)
@@ -30,7 +30,7 @@ static int callback(const void *input_buffer, void *_output_buffer,
   UnifexEnv *env = unifex_alloc_env(NULL);
 
   UnifexPayload payload;
-  unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, frames * FRAME_SIZE, &payload);
+  unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, frames * state->channels * SAMPLE_SIZE, &payload);
   memcpy(payload.data, input_buffer, payload.size);
   if (!send_portaudio_payload(env, state->destination, UNIFEX_SEND_THREADED,
                               &payload)) {
@@ -44,24 +44,28 @@ static int callback(const void *input_buffer, void *_output_buffer,
 }
 
 UNIFEX_TERM create(UnifexEnv *env, UnifexPid destination, int endpoint_id,
-                   int pa_buffer_size, char *latency) {
+                   int pa_buffer_size, char *latency, int max_channels) {
   MEMBRANE_DEBUG(env, "Initializing");
 
   SourceState *state = unifex_alloc_state(env);
   state->is_content_destroyed = 0;
   state->destination = destination;
   state->stream = NULL;
+  
+  double sample_rate = -1.0;
 
   int _latency_ms;
   char *error = init_pa(
       env, MEMBRANE_LOG_TAG, STREAM_DIRECTION_IN, &(state->stream), state,
-      paInt16, // sample format #TODO hardcoded
-      48000,   // sample rate #TODO hardcoded
-      2,       // channels #TODO hardcoded
+      paInt16, // sample format
+      &sample_rate, // device's default sample rate will be selected
+      &max_channels,
       latency, &_latency_ms, pa_buffer_size, endpoint_id, callback);
+  
+  state->channels = max_channels;
 
   UNIFEX_TERM res =
-      error ? create_result_error(env, error) : create_result_ok(env, state);
+      error ? create_result_error(env, error) : create_result_ok(env, state, max_channels, floor(sample_rate));
   unifex_release_state(env, state);
   return res;
 }

--- a/c_src/membrane_portaudio_plugin/source.h
+++ b/c_src/membrane_portaudio_plugin/source.h
@@ -9,6 +9,7 @@
 
 typedef struct _SourceState {
   int is_content_destroyed;
+  int channels;
   PaStream *stream;
   UnifexPid destination; // Where capture thread will send messages
 } SourceState;

--- a/c_src/membrane_portaudio_plugin/source.spec.exs
+++ b/c_src/membrane_portaudio_plugin/source.spec.exs
@@ -8,8 +8,11 @@ spec create(
        destination :: pid,
        endpoint_id :: int,
        pa_buffer_size :: int,
-       latency :: atom
-     ) :: {:ok :: label, state} | {:error :: label, reason :: atom}
+       latency :: atom,
+       max_channels :: int
+     ) ::
+       {:ok :: label, state, channels :: int, sample_rate :: int}
+       | {:error :: label, reason :: atom}
 
 spec destroy(state) :: :ok
 

--- a/c_src/membrane_portaudio_plugin/source.spec.exs
+++ b/c_src/membrane_portaudio_plugin/source.spec.exs
@@ -9,7 +9,8 @@ spec create(
        endpoint_id :: int,
        pa_buffer_size :: int,
        latency :: atom,
-       max_channels :: int
+       max_channels :: int,
+       sample_rate :: int
      ) ::
        {:ok :: label, state, channels :: int, sample_rate :: int}
        | {:error :: label, reason :: atom}

--- a/lib/membrane_portaudio_plugin/sink.ex
+++ b/lib/membrane_portaudio_plugin/sink.ex
@@ -22,8 +22,8 @@ defmodule Membrane.PortAudio.Sink do
 
   def_input_pad :input,
     demand_unit: :bytes,
-    # TODO Add support for different formats
-    accepted_format: %RawAudio{channels: 2, sample_rate: 48_000, sample_format: :s16le}
+    accepted_format:
+      %RawAudio{sample_format: format} when format in [:f32le, :s32le, :s24le, :s16le, :s8, :u8]
 
   def_options endpoint_id: [
                 type: :integer,
@@ -62,7 +62,7 @@ defmodule Membrane.PortAudio.Sink do
   end
 
   @impl true
-  def handle_playing(ctx, state) do
+  def handle_stream_format(:input, %Membrane.RawAudio{} = format, ctx, state) do
     %{
       endpoint_id: endpoint_id,
       ringbuffer_size: ringbuffer_size,
@@ -77,6 +77,9 @@ defmodule Membrane.PortAudio.Sink do
              self(),
              ctx.clock,
              endpoint_id,
+             format.sample_rate,
+             format.channels,
+             format.sample_format,
              ringbuffer_size,
              pa_buffer_size,
              latency

--- a/lib/membrane_portaudio_plugin/source.ex
+++ b/lib/membrane_portaudio_plugin/source.ex
@@ -35,9 +35,18 @@ defmodule Membrane.PortAudio.Source do
                 default: :high,
                 description: "Latency of the output device"
               ],
-              max_channels: [
-                spec: 1..2,
-                default: 2,
+              sample_rate: [
+                spec: non_neg_integer(),
+                default: -1,
+                description: """
+                Sample rate for input device.
+
+                If not set, device's default sample rate will be used.
+                """
+              ],
+              channels: [
+                spec: 0..2,
+                default: 0,
                 description: " Max number of channels that the device will be allowed to output "
               ]
 
@@ -57,7 +66,8 @@ defmodule Membrane.PortAudio.Source do
       endpoint_id: endpoint_id,
       portaudio_buffer_size: pa_buffer_size,
       latency: latency,
-      max_channels: max_channels
+      channels: channels,
+      sample_rate: sample_rate
     } = state
 
     endpoint_id = if endpoint_id == :default, do: @pa_no_device, else: endpoint_id
@@ -68,7 +78,8 @@ defmodule Membrane.PortAudio.Source do
              endpoint_id,
              pa_buffer_size,
              latency,
-             max_channels
+             channels,
+             sample_rate
            ]) do
       Membrane.ResourceGuard.register(
         ctx.resource_guard,

--- a/lib/membrane_portaudio_plugin/source.ex
+++ b/lib/membrane_portaudio_plugin/source.ex
@@ -37,7 +37,7 @@ defmodule Membrane.PortAudio.Source do
               ],
               sample_rate: [
                 spec: non_neg_integer(),
-                default: -1,
+                default: nil,
                 description: """
                 Sample rate for input device.
 
@@ -79,7 +79,7 @@ defmodule Membrane.PortAudio.Source do
              pa_buffer_size,
              latency,
              channels,
-             sample_rate
+             sample_rate || 1
            ]) do
       Membrane.ResourceGuard.register(
         ctx.resource_guard,

--- a/lib/membrane_portaudio_plugin/source.ex
+++ b/lib/membrane_portaudio_plugin/source.ex
@@ -15,7 +15,7 @@ defmodule Membrane.PortAudio.Source do
   # TODO Add support for different formats
   def_output_pad :output,
     mode: :push,
-    accepted_format: %RawAudio{channels: 2, sample_rate: 48_000, sample_format: :s16le}
+    accepted_format: %RawAudio{sample_format: :s16le}
 
   def_options endpoint_id: [
                 type: :integer,
@@ -34,6 +34,11 @@ defmodule Membrane.PortAudio.Source do
                 spec: :low | :high,
                 default: :high,
                 description: "Latency of the output device"
+              ],
+              max_channels: [
+                spec: 1..2,
+                default: 2,
+                description: " Max number of channels that the device will be allowed to output "
               ]
 
   @impl true
@@ -51,13 +56,20 @@ defmodule Membrane.PortAudio.Source do
     %{
       endpoint_id: endpoint_id,
       portaudio_buffer_size: pa_buffer_size,
-      latency: latency
+      latency: latency,
+      max_channels: max_channels
     } = state
 
     endpoint_id = if endpoint_id == :default, do: @pa_no_device, else: endpoint_id
 
-    with {:ok, native} <-
-           SyncExecutor.apply(Native, :create, [self(), endpoint_id, pa_buffer_size, latency]) do
+    with {:ok, native, channels, sample_rate} <-
+           SyncExecutor.apply(Native, :create, [
+             self(),
+             endpoint_id,
+             pa_buffer_size,
+             latency,
+             max_channels
+           ]) do
       Membrane.ResourceGuard.register(
         ctx.resource_guard,
         fn -> SyncExecutor.apply(Native, :destroy, native) end
@@ -66,7 +78,8 @@ defmodule Membrane.PortAudio.Source do
       # TODO Add support for different formats
       {[
          stream_format:
-           {:output, %RawAudio{channels: 2, sample_rate: 48_000, sample_format: :s16le}}
+           {:output,
+            %RawAudio{channels: channels, sample_rate: sample_rate, sample_format: :s16le}}
        ], %{state | native: native}}
     else
       {:error, reason} -> raise "Error: #{inspect(reason)}"


### PR DESCRIPTION
We have observed an issue on some Macbooks, where the source stream wouldn't open. It turns out, the problem was caused by stream parameters being hardcoded.
The solution is to accept the stream with whatever parametrs the device provides.

+ added `max_channels` option in source, allowing for selecting either mono or stereo with fallback to mono
+ in source, device's default sample rate is used
+ sink takes sample_rate, channels and sample_format from incoming caps
