### PR TITLE
Bump bundlex dependency to 1.4, fix for cross-compile on OSX.

### DIFF
--- a/bundlex.exs
+++ b/bundlex.exs
@@ -44,10 +44,10 @@ defmodule Membrane.PortAudio.BundlexProject do
         ],
         preprocessor: Unifex
       ]
-    ] ++ os_specific(Bundlex.get_target())
+    ] ++ os_specific(Bundlex.platform())
   end
 
-  defp os_specific(%{os: "darwin" <> _rest}) do
+  defp os_specific(:macosx) do
     [
       osx_permissions: [
         interface: :nif,

--- a/lib/membrane_portaudio_plugin/osx_permissions.ex
+++ b/lib/membrane_portaudio_plugin/osx_permissions.ex
@@ -1,4 +1,4 @@
-if Bundlex.get_target().os |> String.starts_with?("darwin") do
+if Bundlex.platform() == :macosx do
   defmodule Membrane.PortAudio.OSXPermissions do
     @moduledoc false
 

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Membrane.PortAudio.Mixfile do
       {:membrane_common_c, "~> 0.16.0"},
       {:bunch, "~> 1.5"},
       {:membrane_raw_audio_format, "~> 0.12.0"},
-      {:bundlex, "~> 1.3"},
+      {:bundlex, "~> 1.4"},
       {:membrane_precompiled_dependency_provider, "~> 0.1.0"},
       # Testing
       {:mockery, "~> 2.1", runtime: false},


### PR DESCRIPTION
Updated to use `Bundlex.platform()` to better support cross-compilation while on OSX.