### PR TITLE
Return devices

### DIFF
--- a/c_src/membrane_portaudio_plugin/pa_devices.c
+++ b/c_src/membrane_portaudio_plugin/pa_devices.c
@@ -41,6 +41,7 @@ UNIFEX_TERM list(UnifexEnv *env)
         strcpy(devices[i].name, device_info->name);
       }
 
+      devices[i].id = i;
       devices[i].max_output_channels = device_info->maxOutputChannels;
       devices[i].max_input_channels = device_info->maxInputChannels;
       devices[i].default_sample_rate = device_info->defaultSampleRate;

--- a/c_src/membrane_portaudio_plugin/pa_devices.c
+++ b/c_src/membrane_portaudio_plugin/pa_devices.c
@@ -40,6 +40,7 @@ UNIFEX_TERM list(UnifexEnv *env)
       devices[i].name = names[i];
       devices[i].max_output_channels = device_info->maxOutputChannels;
       devices[i].max_input_channels = device_info->maxInputChannels;
+      devices[i].is_default = i == default_input_id || i == default_output_id;
     }
   }
 

--- a/c_src/membrane_portaudio_plugin/pa_devices.c
+++ b/c_src/membrane_portaudio_plugin/pa_devices.c
@@ -5,45 +5,48 @@ UNIFEX_TERM list(UnifexEnv *env)
   Pa_Initialize();
   int numDevices = Pa_GetDeviceCount();
   device devices[numDevices];
-  char names[numDevices][255];
   if (numDevices < 0)
   {
     printf("\nERROR: Pa_CountDevices returned 0x%x\n", numDevices);
-    return list_result_ok(env, devices, numDevices);
+    return list_result(env, devices, numDevices);
   }
   else if (numDevices == 0)
   {
-    printf("\nNo audio devices found\n");
+    return list_result(env, devices, numDevices);
   }
   else
   {
-    printf("\nAvailable audio devices:\n\n");
     int default_input_id = Pa_GetDefaultInputDevice();
     int default_output_id = Pa_GetDefaultOutputDevice();
     for (int i = 0; i < numDevices; i++)
     {
       const PaDeviceInfo *device_info = Pa_GetDeviceInfo(i);
-      const char *default_str =
-          i == default_input_id
-              ? " (default input)"
-          : i == default_output_id ? " (default output)"
-                                   : "";
 
-      printf("%s%s\r\n\tid: %d\r\n\tmax_input_channels: "
-             "%d\r\n\tmax_output_channels: %d\r\n\n",
-             device_info->name, default_str, i, device_info->maxInputChannels,
-             device_info->maxOutputChannels);
+      if (i == default_input_id)
+      {
+        devices[i].default_device = DEFAULT_DEVICE_INPUT;
+      }
+      else if (i == default_output_id)
+      {
+        devices[i].default_device = DEFAULT_DEVICE_OUTPUT;
+      }
+      else
+      {
+        devices[i].default_device = DEFAULT_DEVICE_FALSE;
+      }
 
-      strncpy(names[i], device_info->name, 255);
+      devices[i].name = malloc(strlen(device_info->name) + 1);
+      if (device_info->name != NULL)
+      {
+        strcpy(devices[i].name, device_info->name);
+      }
 
-      devices[i].id = i;
-      devices[i].name = names[i];
       devices[i].max_output_channels = device_info->maxOutputChannels;
       devices[i].max_input_channels = device_info->maxInputChannels;
-      devices[i].is_default = i == default_input_id || i == default_output_id;
+      devices[i].default_sample_rate = device_info->defaultSampleRate;
     }
   }
 
   Pa_Terminate();
-  return list_result_ok(env, devices, numDevices);
+  return list_result(env, devices, numDevices);
 }

--- a/c_src/membrane_portaudio_plugin/pa_devices.c
+++ b/c_src/membrane_portaudio_plugin/pa_devices.c
@@ -39,7 +39,7 @@ UNIFEX_TERM list(UnifexEnv *env)
       devices[i].id = i;
       devices[i].name = names[i];
       devices[i].max_output_channels = device_info->maxOutputChannels;
-      devices[i].max_output_channels = device_info->maxInputChannels;
+      devices[i].max_input_channels = device_info->maxInputChannels;
     }
   }
 

--- a/c_src/membrane_portaudio_plugin/pa_devices.c
+++ b/c_src/membrane_portaudio_plugin/pa_devices.c
@@ -1,31 +1,48 @@
 #include "pa_devices.h"
 
-UNIFEX_TERM list(UnifexEnv *env) {
+UNIFEX_TERM list(UnifexEnv *env)
+{
   Pa_Initialize();
   int numDevices = Pa_GetDeviceCount();
-  if (numDevices < 0) {
+  device devices[numDevices];
+  char names[numDevices][255];
+  if (numDevices < 0)
+  {
     printf("\nERROR: Pa_CountDevices returned 0x%x\n", numDevices);
-    return list_result(env);
-  } else if (numDevices == 0) {
+    return list_result_ok(env, devices, numDevices);
+  }
+  else if (numDevices == 0)
+  {
     printf("\nNo audio devices found\n");
-  } else {
+  }
+  else
+  {
     printf("\nAvailable audio devices:\n\n");
     int default_input_id = Pa_GetDefaultInputDevice();
     int default_output_id = Pa_GetDefaultOutputDevice();
-    for (int i = 0; i < numDevices; i++) {
+    for (int i = 0; i < numDevices; i++)
+    {
       const PaDeviceInfo *device_info = Pa_GetDeviceInfo(i);
       const char *default_str =
           i == default_input_id
               ? " (default input)"
-              : i == default_output_id ? " (default output)" : "";
+          : i == default_output_id ? " (default output)"
+                                   : "";
 
       printf("%s%s\r\n\tid: %d\r\n\tmax_input_channels: "
              "%d\r\n\tmax_output_channels: %d\r\n\n",
              device_info->name, default_str, i, device_info->maxInputChannels,
              device_info->maxOutputChannels);
+
+      strncpy(names[i], device_info->name, 255);
+
+      devices[i].id = i;
+      devices[i].name = names[i];
+      devices[i].max_output_channels = device_info->maxOutputChannels;
+      devices[i].max_output_channels = device_info->maxInputChannels;
     }
   }
 
   Pa_Terminate();
-  return list_result(env);
+  return list_result_ok(env, devices, numDevices);
 }

--- a/c_src/membrane_portaudio_plugin/pa_devices.spec.exs
+++ b/c_src/membrane_portaudio_plugin/pa_devices.spec.exs
@@ -5,7 +5,8 @@ type(
     id: int,
     name: string,
     max_input_channels: int,
-    max_output_channels: int
+    max_output_channels: int,
+    is_default: bool
   }
 )
 

--- a/c_src/membrane_portaudio_plugin/pa_devices.spec.exs
+++ b/c_src/membrane_portaudio_plugin/pa_devices.spec.exs
@@ -1,13 +1,15 @@
 module Membrane.PortAudio.Devices
 
 type(
-  device :: %Device{
+  device :: %Membrane.PortAudio.Device{
     id: int,
     name: string,
     max_input_channels: int,
     max_output_channels: int,
-    is_default: bool
+    default_sample_rate: float,
+    default_device: default_device
   }
 )
 
-spec list() :: {:ok :: label, devices :: [device]}
+type(default_device :: false | :input | :output)
+spec list() :: devices :: [device]

--- a/c_src/membrane_portaudio_plugin/pa_devices.spec.exs
+++ b/c_src/membrane_portaudio_plugin/pa_devices.spec.exs
@@ -1,3 +1,12 @@
 module Membrane.PortAudio.Devices
 
-spec list() :: :ok
+type(
+  device :: %Device{
+    id: int,
+    name: string,
+    max_input_channels: int,
+    max_output_channels: int
+  }
+)
+
+spec list() :: {:ok :: label, devices :: [device]}

--- a/lib/membrane_portaudio.ex
+++ b/lib/membrane_portaudio.ex
@@ -20,6 +20,8 @@ defmodule Membrane.PortAudio do
   @spec print_devices() :: :ok
   def print_devices() do
     Application.ensure_all_started(:membrane_portaudio_plugin)
+
     __MODULE__.SyncExecutor.apply(__MODULE__.Devices, :list, [])
+    |> IO.inspect()
   end
 end

--- a/lib/membrane_portaudio_plugin/device.ex
+++ b/lib/membrane_portaudio_plugin/device.ex
@@ -1,0 +1,10 @@
+defmodule Membrane.PortAudio.Device do
+  defstruct [
+    :id,
+    :name,
+    :max_input_channels,
+    :max_output_channels,
+    :is_default,
+    :default_sample_rate
+  ]
+end


### PR DESCRIPTION
I want to ship this in a desktop app. So, I'd like to call `Membrane.PortAudio.Devices.list()` and get back a list of devices so the user can select one.

I implemented it by adding a `device` spec and iterating over the DeviceInfo structs to create `devices`. I then return those in a list. 

This is my first crack at NIF's so be gentle.